### PR TITLE
Rename enram to aloftdata

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -18,7 +18,7 @@ See our guide on [how to create a great issue](https://code-review.tidyverse.org
 
 ### Pull request process
 
-*   Fork the package and clone onto your computer. If you haven't done this before, we recommend using `usethis::create_from_github("enram/getRad", fork = TRUE)`.
+*   Fork the package and clone onto your computer. If you haven't done this before, we recommend using `usethis::create_from_github("aloftdata/getRad", fork = TRUE)`.
 
 *   Install all development dependencies with `devtools::install_dev_deps()`, and then make sure the package passes R CMD check by running `devtools::check()`. 
     If R CMD check doesn't pass cleanly, it's a good idea to ask for help before continuing. 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -21,8 +21,8 @@ authors:
   email: peter.desmet@inbo.be
   orcid: https://orcid.org/0000-0002-8442-8025
   affiliation: Research Institute for Nature and Forest (INBO)
-repository-code: https://github.com/enram/getRad
-url: https://enram.github.io/getRad/
+repository-code: https://github.com/aloftdata/getRad
+url: https://aloftdata.github.io/getRad/
 contact:
 - family-names: Kranstauber
   given-names: Bart

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,8 +11,6 @@ Description: This package facilitates downloading radar data for
     biological research. Currently the main functionality is downloading
     polar volume data from open repositories of European countries.
 License: MIT + file LICENSE
-URL: https://github.com/enram/getRad, https://enram.github.io/getRad/
-BugReports: https://github.com/enram/getRad/issues
 Depends: 
     R (>= 4.1.0)
 Imports: 
@@ -23,6 +21,8 @@ Imports:
     httr2,
     purrr,
     rlang
+URL: https://github.com/aloftdata/getRad, https://aloftdata.github.io/getRad/
+BugReports: https://github.com/aloftdata/getRad/issues
 Suggests:
     askpass,
     htmltools,

--- a/README.Rmd
+++ b/README.Rmd
@@ -17,8 +17,8 @@ knitr::opts_chunk$set(
 
 <!-- badges: start -->
 [![CRAN status](https://www.r-pkg.org/badges/version/getRad)](https://CRAN.R-project.org/package=getRad)
-[![R-CMD-check](https://github.com/enram/getRad/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/enram/getRad/actions/workflows/R-CMD-check.yaml)
-[![codecov](https://codecov.io/gh/enram/getRad/branch/main/graph/badge.svg)](https://app.codecov.io/gh/enram/getRad/)
+[![R-CMD-check](https://github.com/aloftdata/getRad/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/aloftdata/getRad/actions/workflows/R-CMD-check.yaml)
+[![codecov](https://codecov.io/gh/aloftdata/getRad/branch/main/graph/badge.svg)](https://app.codecov.io/gh/aloftdata/getRad/)
 [![repo status](https://www.repostatus.org/badges/latest/wip.svg)](https://www.repostatus.org/#wip)
 <!-- badges: end -->
 
@@ -30,7 +30,7 @@ You can install the development version of `getRad` from [GitHub](https://github
 
 ``` r
 # install.packages("devtools")
-devtools::install_github("enram/getRad")
+devtools::install_github("aloftdata/getRad")
 ```
 
 For the time being the package is not yet released on CRAN.
@@ -53,7 +53,7 @@ plot(calculate_vp(pvol, h_layer = 50, n_layer = 40))
 
 ## Meta
 
-- We welcome [contributions](https://enram.github.io/getRad/CONTRIBUTING.html) including bug reports.
+- We welcome [contributions](https://aloftdata.github.io/getRad/CONTRIBUTING.html) including bug reports.
 - License: MIT
-- Get [citation information](https://enram.github.io/getRad/authors.html#citation) for getRad in R doing `citation("getRad")`.
-- Please note that this project is released with a [Contributor Code of Conduct](https://enram.github.io/getRad/CODE_OF_CONDUCT.html). By participating in this project you agree to abide by its terms.
+- Get [citation information](https://aloftdata.github.io/getRad/authors.html#citation) for getRad in R doing `citation("getRad")`.
+- Please note that this project is released with a [Contributor Code of Conduct](https://aloftdata.github.io/getRad/CODE_OF_CONDUCT.html). By participating in this project you agree to abide by its terms.

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 
 [![CRAN
 status](https://www.r-pkg.org/badges/version/getRad)](https://CRAN.R-project.org/package=getRad)
-[![R-CMD-check](https://github.com/enram/getRad/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/enram/getRad/actions/workflows/R-CMD-check.yaml)
-[![codecov](https://codecov.io/gh/enram/getRad/branch/main/graph/badge.svg)](https://app.codecov.io/gh/enram/getRad/)
+[![R-CMD-check](https://github.com/aloftdata/getRad/actions/workflows/R-CMD-check.yaml/badge.svg)](https://github.com/aloftdata/getRad/actions/workflows/R-CMD-check.yaml)
+[![codecov](https://codecov.io/gh/aloftdata/getRad/branch/main/graph/badge.svg)](https://app.codecov.io/gh/aloftdata/getRad/)
 [![repo
 status](https://www.repostatus.org/badges/latest/wip.svg)](https://www.repostatus.org/#wip)
 <!-- badges: end -->
@@ -27,7 +27,7 @@ You can install the development version of `getRad` from
 
 ``` r
 # install.packages("devtools")
-devtools::install_github("enram/getRad")
+devtools::install_github("aloftdata/getRad")
 ```
 
 For the time being the package is not yet released on CRAN.
@@ -65,12 +65,12 @@ plot(calculate_vp(pvol, h_layer = 50, n_layer = 40))
 ## Meta
 
 - We welcome
-  [contributions](https://enram.github.io/getRad/CONTRIBUTING.html)
+  [contributions](https://aloftdata.github.io/getRad/CONTRIBUTING.html)
   including bug reports.
 - License: MIT
 - Get [citation
-  information](https://enram.github.io/getRad/authors.html#citation) for
+  information](https://aloftdata.github.io/getRad/authors.html#citation) for
   getRad in R doing `citation("getRad")`.
 - Please note that this project is released with a [Contributor Code of
-  Conduct](https://enram.github.io/getRad/CODE_OF_CONDUCT.html). By
+  Conduct](https://aloftdata.github.io/getRad/CODE_OF_CONDUCT.html). By
   participating in this project you agree to abide by its terms.

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,4 +1,4 @@
-url: https://enram.github.io/getRad/
+url: https://aloftdata.github.io/getRad/
 
 template:
   bootstrap: 5

--- a/codemeta.json
+++ b/codemeta.json
@@ -4,9 +4,9 @@
   "identifier": "getRad",
   "description": "What the package does (one paragraph).",
   "name": "getRad: Access and Standardize Radar Data",
-  "relatedLink": "https://enram.github.io/getRad/",
-  "codeRepository": "https://github.com/enram/getRad",
-  "issueTracker": "https://github.com/enram/getRad/issues",
+  "relatedLink": "https://aloftdata.github.io/getRad/",
+  "codeRepository": "https://github.com/aloftdata/getRad",
+  "issueTracker": "https://github.com/aloftdata/getRad/issues",
   "license": "https://spdx.org/licenses/MIT",
   "version": "0.0.0.9000",
   "programmingLanguage": {
@@ -59,6 +59,6 @@
     "SystemRequirements": null
   },
   "fileSize": "2.744KB",
-  "readme": "https://github.com/enram/getRad/blob/main/README.md",
-  "contIntegration": ["https://github.com/enram/getRad/actions/workflows/R-CMD-check.yaml", "https://github.com/enram/getRad/actions/workflows/test-coverage.yaml"]
+  "readme": "https://github.com/aloftdata/getRad/blob/main/README.md",
+  "contIntegration": ["https://github.com/aloftdata/getRad/actions/workflows/R-CMD-check.yaml", "https://github.com/aloftdata/getRad/actions/workflows/test-coverage.yaml"]
 }

--- a/man/getRad-package.Rd
+++ b/man/getRad-package.Rd
@@ -11,9 +11,9 @@ This package facilitates downloading radar data for biological research. Current
 \seealso{
 Useful links:
 \itemize{
-  \item \url{https://github.com/enram/getRad}
-  \item \url{https://enram.github.io/getRad/}
-  \item Report bugs at \url{https://github.com/enram/getRad/issues}
+  \item \url{https://github.com/aloftdata/getRad}
+  \item \url{https://aloftdata.github.io/getRad/}
+  \item Report bugs at \url{https://github.com/aloftdata/getRad/issues}
 }
 
 }


### PR DESCRIPTION
This PR corrects the GitHub organization name from `enram` to `aloftdata`, so URLs point correctly to:

https://github.com/aloftdata/getRad
https://aloftdata.github.io/getRad

Note: since the website for getRad is not publicly announced, I will _not_ create a redirect for https://enram.github.io/getRad.