### PR TITLE
Fix bug where more data was retreived in `get_vpts` as was requested.

### DIFF
--- a/R/get_vpts.R
+++ b/R/get_vpts.R
@@ -139,8 +139,10 @@ get_vpts <- function(radar,
   if (!inherits(date, "Interval")) {
     date_interval <-
       lubridate::interval(
+        ### from the start of the datetime
         lubridate::as_datetime(date),
-        lubridate::as_datetime(date) +
+        ### to the end of the day
+        lubridate::floor_date(lubridate::as_datetime(date), "day") +
           lubridate::ddays(1) -
           lubridate::dseconds(1)
       )

--- a/R/get_vpts.R
+++ b/R/get_vpts.R
@@ -139,12 +139,10 @@ get_vpts <- function(radar,
   if (!inherits(date, "Interval")) {
     date_interval <-
       lubridate::interval(
-        ### from the start of the datetime
+        ### starting at the datetime itself
         lubridate::as_datetime(date),
         ### to the end of the day
-        lubridate::floor_date(lubridate::as_datetime(date), "day") +
-          lubridate::ddays(1) -
-          lubridate::dseconds(1)
+        end_of_day(date)
       )
   } else {
     date_interval <- date

--- a/R/utils.R
+++ b/R/utils.R
@@ -55,6 +55,23 @@ round_interval <- function(x, unit = "day"){
   )
 }
 
+#' Get the end of the day for a given datetime
+#'
+#' @param date A datetime object or a character string that can be coerced to a
+#'   datetime object.
+#'
+#' @return A datetime object representing the end of the day.
+#' @noRd
+#'
+#' @examples
+#' end_of_day("2016-03-05")
+#' end_of_day("2020-07-12 11:01:33")
+end_of_day <- function(date){
+  lubridate::floor_date(lubridate::as_datetime(date), "day") +
+    lubridate::ddays(1) -
+    lubridate::dseconds(1)
+}
+
 #' Set the list names to the unique value of the radar column
 #'
 #'

--- a/tests/testthat/test-get_vpts.R
+++ b/tests/testthat/test-get_vpts.R
@@ -279,6 +279,22 @@ test_that("get_vpts() supports POSIXct dates", {
 
 })
 
+test_that("get_vpts() only returns the data for the requested day", {
+  # Check bug where one extra day of data was returned due to rounding error
+
+  radar_interval <- get_vpts(
+    radar = "nlhrw",
+    date = as.POSIXct("2025-05-10 13:40:37", tz = "Europe/Berlin"),
+    return_type = "tibble"
+  )
+
+  expect_equal(
+    unique(lubridate::floor_date(radar_interval$datetime, "day")),
+    lubridate::ymd("2025-05-10", tz = "UTC")
+  )
+
+})
+
 test_that("get_vpts() supports date intervals with hours and minutes", {
   skip_if_offline()
 


### PR DESCRIPTION
I made a change to the interval building mechanics of `get_vpts()` so data is only ever retrieved for the days that are requested. I also added a helper wrapping some code to ceiling a datetime to the end of that date, I did this for readability. I also added an extra test to cover this bug. 