### PR TITLE
Fix bug where `get_vpts()` didn't work for `ecog-04003`

### DIFF
--- a/R/get_vpts_aloft.R
+++ b/R/get_vpts_aloft.R
@@ -102,7 +102,7 @@ get_vpts_aloft <- function(radar_odim_code,
         "{dir}/{radar}_vpts_{year}{month}{day}.csv",
         dir = string_extract(path, ".+/.+/.+/[0-9]{4}"),
         radar = string_extract(path, "(?<=daily/).{5}"),
-        year = string_extract(path, "[0-9]{4}"),
+        year = string_extract(path, "(?<=\\/)[0-9]{4}"),
         month = string_extract(path, "(?<=/)[0-9]{2}(?=/)"),
         day = string_extract(path, "[0-9]{2}$")
       )


### PR DESCRIPTION
Fixed a bug introduced in the refactoring of the the regex pattern used to extract the `year` from the `path` variable, narrowing it down to match a single digit after a forward slash instead of a four-digit year. This way it will work for `ecog-04003`. 

