### PR TITLE
Exclude `get_vpts_aloft()` from pkgdown website.

### DIFF
--- a/R/get_vpts_aloft.R
+++ b/R/get_vpts_aloft.R
@@ -30,6 +30,7 @@
 #'
 #' @importFrom dplyr .data
 #' @importFrom lubridate %within%
+#' @keywords internal
 #'
 #' @examplesIf interactive()
 #'

--- a/man/get_vpts_aloft.Rd
+++ b/man/get_vpts_aloft.Rd
@@ -56,3 +56,4 @@ get_vpts_aloft(
 )
 \dontshow{\}) # examplesIf}
 }
+\keyword{internal}


### PR DESCRIPTION
I added a keyword to the roxygen documentation of `get_vpts_aloft()` so it's not included in the pkgdown website. 