### PR TITLE
Add `rmi_data_coverage()` to `get_vpts_rmi()` branch.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,6 +36,7 @@ Imports:
     lubridate,
     purrr (>= 1.0.0),
     rlang,
+    tidyr,
     tools,
     utils,
     vroom,
@@ -51,7 +52,6 @@ Suggests:
     rnaturalearthdata,
     sf,
     testthat (>= 3.0.0),
-    tidyr,
     vol2birdR,
     withr
 VignetteBuilder: 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,6 +36,7 @@ Imports:
     lubridate,
     purrr (>= 1.0.0),
     rlang,
+    tibble,
     tidyr,
     tools,
     utils,

--- a/R/rmi_data_coverage.R
+++ b/R/rmi_data_coverage.R
@@ -45,8 +45,9 @@ rmi_data_coverage <- function(radar = NULL, year = NULL) {
 
   years_covered_by_rmi <- as.integer(unique(unlist(radar_year_combos)))
 
-  if (!year %in% years_covered_by_rmi && use_year_filter) {
-    cli::cli_abort("Requested year {year} is not present in RMI coverage")
+  if (!all(year %in% years_covered_by_rmi) && use_year_filter) {
+    cli::cli_abort("Requested year {year[!year %in% years_covered_by_rmi]} is
+                   not present in RMI coverage")
   }
 
   radar_year_combos |>

--- a/R/rmi_data_coverage.R
+++ b/R/rmi_data_coverage.R
@@ -1,3 +1,11 @@
+#' Get HTML from a URL
+#'
+#' @param url URL to get the HTML from.
+#' @param use_cache Logical. If `TRUE`, use the cache. If `FALSE`, do not use
+#'   the cache.
+#'
+#' @return HTML content from the URL as a xml2 html object.
+#' @noRd
 get_html <- function(url, use_cache = TRUE) {
   httr2::request(url) |>
     req_user_agent_getrad() |>
@@ -7,6 +15,13 @@ get_html <- function(url, use_cache = TRUE) {
     httr2::resp_body_html()
 }
 
+#' Get an html element using regex selection from a html object.
+#'
+#' @param html html object from the `xml2` package.
+#' @param regex regex to select the element.
+#'
+#' @return A character vector with the selected elements.
+#' @noRd
 get_element_regex <- function(html, regex) {
   html |>
     xml2::xml_find_all(".//a") |>

--- a/R/rmi_data_coverage.R
+++ b/R/rmi_data_coverage.R
@@ -15,6 +15,23 @@ get_element_regex <- function(html, regex) {
     (\(vec) vec[!is.na(vec)])()
 }
 
+#' Get RMI data coverage
+#'
+#' This function retrieves the RMI data coverage for a given radar and year.
+#'
+#' @param radar Optional. Character vector of radars to get coverage for.
+#' @param year Optional. Integer vector of years to get coverage for.
+#'
+#' @return A tibble with RMI data coverage.
+#' @noRd
+#'
+#' @examplesIf interactive()
+#' # Get coverage for all radars and years
+#' rmi_data_coverage()
+#' # For a single radar, for a few years
+#' rmi_data_coverage(radar = "behel", year = c(2020, 2021))
+#' # For several radars for a single year
+#' rmi_data_coverage(radar = c("frave", "bezav", "nlhrw"), year = 2024)
 rmi_data_coverage <- function(radar = NULL, year = NULL) {
   base_url <-
     "https://opendata.meteo.be/ftp/observations/radar/vbird"

--- a/R/rmi_data_coverage.R
+++ b/R/rmi_data_coverage.R
@@ -81,8 +81,9 @@ rmi_data_coverage <- function(radar = NULL, year = NULL) {
   years_covered_by_rmi <- as.integer(unique(unlist(radar_year_combos)))
 
   if (!all(year %in% years_covered_by_rmi) && use_year_filter) {
-    cli::cli_abort("Requested year {year[!year %in% years_covered_by_rmi]} is
-                   not present in RMI coverage")
+    cli::cli_abort("Requested year {year[!year %in% years_covered_by_rmi]}
+     not present in RMI coverage",
+                   class = "getRad_error_date_not_found")
   }
 
   radar_year_combos |>

--- a/R/rmi_data_coverage.R
+++ b/R/rmi_data_coverage.R
@@ -1,0 +1,55 @@
+get_html <- function(url, use_cache = TRUE) {
+  httr2::request(url) |>
+    req_user_agent_getrad() |>
+    req_retry_getrad() |>
+    req_cache_getrad(use_cache = use_cache) |>
+    httr2::req_perform() |>
+    httr2::resp_body_html()
+}
+
+get_element_regex <- function(html, regex){
+  html |>
+    xml2::xml_find_all(".//a") |>
+    xml2::xml_text() |>
+    string_extract(regex) |>
+    (\(vec) vec[!is.na(vec)])()
+}
+
+rmi_data_coverage <- function(use_cache = TRUE) {
+  base_url <-
+    "https://opendata.meteo.be/ftp/observations/radar/vbird"
+
+  purrr::map(
+    found_radars <- get_element_regex(get_html(base_url, use_cache), "[a-z]{5}(?=\\/)"),
+    \(radar) get_element_regex(get_html(file.path(base_url, radar), use_cache), "[0-9]{4}")
+  ) |>
+    purrr::set_names(found_radars) |>
+    (\(years_per_radar)    {
+      purrr::map2(
+        years_per_radar,
+        names(years_per_radar),
+        ~ file.path(base_url, .y, .x)
+      )
+    })() |>
+    purrr::map(\(year_url) {
+      purrr::map(year_url, ~ get_element_regex(
+        get_html(.x, use_cache),
+        "[a-z]{5}_vpts_.+"
+      )) |>
+        purrr::set_names(basename(year_url))
+    }) |>
+    tibble::enframe(name = "radar", value = "years") |>
+    tidyr::unnest_wider(col = "years") |>
+    tidyr::pivot_longer(cols = -"radar", names_to = "year", values_to = "file") |>
+    tidyr::unnest_longer("file") |>
+    dplyr::mutate(
+      file = unlist(file),
+      date = lubridate::ymd(string_extract(file, "[0-9]{8}(?=\\.txt)")),
+      directory = file.path(
+        string_replace(base_url, ".+(?<=\\/ftp)", ""),
+        radar,
+        year
+      )
+    ) |>
+    dplyr::select("directory", "file", "radar", "date")
+}

--- a/R/rmi_data_coverage.R
+++ b/R/rmi_data_coverage.R
@@ -71,7 +71,10 @@ rmi_data_coverage <- function(radar = NULL, year = NULL) {
   radar_year_combos <-
     purrr::map(
       found_radars,
-      \(radar) get_element_regex(get_html(file.path(base_url, radar)), "[0-9]{4}")
+      \(radar) get_element_regex(
+        get_html(file.path(base_url, radar)),
+        "[0-9]{4}"
+      )
     ) |>
     purrr::set_names(found_radars)
 
@@ -112,9 +115,11 @@ rmi_data_coverage <- function(radar = NULL, year = NULL) {
     }) |>
     tibble::enframe(name = "radar", value = "years") |>
     tidyr::unnest_wider(col = "years") |>
-    tidyr::pivot_longer(cols = -"radar",
-                        names_to = "year",
-                        values_to = "file") |>
+    tidyr::pivot_longer(
+      cols = -"radar",
+      names_to = "year",
+      values_to = "file"
+    ) |>
     tidyr::unnest_longer("file") |>
     dplyr::mutate(
       file = unlist(file),

--- a/R/utils.R
+++ b/R/utils.R
@@ -363,7 +363,9 @@ fetch_from_url_raw <- function(urls, use_cache = TRUE) {
     # Set retry conditions
     purrr::map(req_retry_getrad) |>
     # Set throttling so we don't overwhelm data sources
-    purrr::map(httr2::req_throttle, capacity = 30) |>
+    purrr::map(\(req) {httr2::req_throttle(req,
+                                           capacity = 30,
+                                           fill_time_s = 30)}) |>
     # Optionally cache the responses
     purrr::map(req_cache_getrad) |>
     # Perform the requests in parallel

--- a/R/utils.R
+++ b/R/utils.R
@@ -368,9 +368,7 @@ fetch_from_url_raw <- function(urls, use_cache = TRUE) {
     purrr::map(req_cache_getrad) |>
     # Perform the requests in parallel
     httr2::req_perform_parallel(progress = interactive()) |>
-    # Fetch the response bodies and parse it using vroom
-    ## A helper in bioRad (validate_vpts()) that we call indirectly via
-    # " bioRad::as.vpts() currently doesn't support factors: bioRad v0.8.1
+    # Fetch the response bodies
     purrr::map(httr2::resp_body_raw)
 }
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -396,34 +396,6 @@ read_lines_from_url <- function(urls, use_cache = TRUE) {
     ))
 }
 
-#' Check if a URL exists
-#'
-#' This function sends a HEAD request to check if a URL exists. It returns
-#' `TRUE` if the URL exists and `FALSE` if it does not.
-#'
-#' @param url Single URLs as a character to check for existence.
-#' @return Logical value indicating whether the URL exists (TRUE) or not
-#'   (FALSE).
-#' @noRd
-url_exists <- purrr::possibly(
-  function(url) {
-    url_does_not_exist <- httr2::request(url) |>
-      req_user_agent_getrad() |>
-      # Retry, but give up quickly
-      httr2::req_retry(
-        max_tries = 30,
-        max_seconds = 10
-      ) |>
-      httr2::req_method("HEAD") |>
-      httr2::req_perform() |>
-      httr2::resp_is_error()
-
-    return(!url_does_not_exist)
-  },
-  otherwise = FALSE, quiet = TRUE
-)
-
-
 check_odim_nexrad_scalar <- function(x) {
   if (!is_odim_nexrad_scalar(x)) {
     cli::cli_abort(

--- a/R/utils.R
+++ b/R/utils.R
@@ -362,6 +362,8 @@ fetch_from_url_raw <- function(urls, use_cache = TRUE) {
     purrr::map(req_user_agent_getrad) |>
     # Set retry conditions
     purrr::map(req_retry_getrad) |>
+    # Set throttling so we don't overwhelm data sources
+    purrr::map(httr2::req_throttle, capacity = 30) |>
     # Optionally cache the responses
     purrr::map(req_cache_getrad) |>
     # Perform the requests in parallel

--- a/tests/testthat/test-rmi_data_coverage.R
+++ b/tests/testthat/test-rmi_data_coverage.R
@@ -1,0 +1,55 @@
+test_that("rmi_data_coverage() returns a tibble", {
+  skip_if_offline("data.meteo.be")
+
+  expect_s3_class(rmi_data_coverage(), "tbl_df")
+})
+
+test_that("rmi_data_coverage() returns expected columns", {
+  expect_named(
+    rmi_data_coverage(),
+    c(
+      "directory",
+      "file",
+      "radar",
+      "date"
+    )
+  )
+})
+
+test_that("rmi_data_coverage() returns known radars and years", {
+  cov <- rmi_data_coverage()
+  expect_in(
+    cov$radar,
+    c(
+      "behel",
+      "bejab",
+      "bewid",
+      "bezav",
+      "deess",
+      "denhb",
+      "frabb",
+      "frave",
+      "nldhl",
+      "nlhrw"
+    )
+  )
+
+  expect_in(
+    lubridate::year(cov$date),
+    seq(2019, 2025)
+  )
+})
+
+test_that("rmi_data_coverage() allows selection on year", {
+  expect_identical(
+    unique(lubridate::year(rmi_data_coverage(year = 2022)$date)),
+    2022
+  )
+})
+
+test_that("rmi_data_coverage() allows selection on radar", {
+  expect_identical(
+    unique(rmi_data_coverage(radar = "bejab")$radar),
+    "bejab"
+  )
+})

--- a/tests/testthat/test-rmi_data_coverage.R
+++ b/tests/testthat/test-rmi_data_coverage.R
@@ -1,10 +1,12 @@
 test_that("rmi_data_coverage() returns a tibble", {
-  skip_if_offline("data.meteo.be")
+  skip_if_offline("opendata.meteo.be")
 
   expect_s3_class(rmi_data_coverage(), "tbl_df")
 })
 
 test_that("rmi_data_coverage() returns expected columns", {
+  skip_if_offline("opendata.meteo.be")
+
   expect_named(
     rmi_data_coverage(),
     c(
@@ -17,6 +19,8 @@ test_that("rmi_data_coverage() returns expected columns", {
 })
 
 test_that("rmi_data_coverage() returns known radars and years", {
+  skip_if_offline("opendata.meteo.be")
+
   cov <- rmi_data_coverage()
   expect_in(
     cov$radar,
@@ -41,6 +45,8 @@ test_that("rmi_data_coverage() returns known radars and years", {
 })
 
 test_that("rmi_data_coverage() allows selection on year", {
+  skip_if_offline("opendata.meteo.be")
+
   expect_identical(
     unique(lubridate::year(rmi_data_coverage(year = 2022)$date)),
     2022
@@ -48,6 +54,8 @@ test_that("rmi_data_coverage() allows selection on year", {
 })
 
 test_that("rmi_data_coverage() allows selection on radar", {
+  skip_if_offline("opendata.meteo.be")
+
   expect_identical(
     unique(rmi_data_coverage(radar = "bejab")$radar),
     "bejab"


### PR DESCRIPTION
This pull request exists so I can experiment with some R CMD CHECK runs on windows. On #53 I'm having some intermittent SSL/TSL errors on windows only. I believe it might be a server capacity thing, for which I want to try two things:

:exclamation:  **I've set the base branch as `main` so the CI will run, but this branch is not intended to be merged into main.** 

1) Put less load on the server by building urls from coverage instead of by generating them and trying them, then querying them (reduces requests by more than half)
2) Implementing capacity/rate based throttling, maybe package wide, maybe just for RMI. Maybe optional sequential requests for RMI? 