### PR TITLE
Add support for Swedish radar data (fix #96)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # getRad (development version)
 
-* Support downloading Swedish data (#96)
+* Support downloading Swedish data (#96).
 
 # getRad 0.2.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # getRad (development version)
 
+* Support downloading Swedish data (#96)
+
 # getRad 0.2.0
 
 * New function `get_weather_radars()` retrieves metadata for OPERA weather radars (#15, #54).

--- a/R/get_pvol.R
+++ b/R/get_pvol.R
@@ -132,6 +132,7 @@ select_get_pvol_function <- function(radar, ..., call = rlang::caller_env()) {
     cntry_code == "de" ~ "get_pvol_de",
     cntry_code == "ee" ~ "get_pvol_ee",
     cntry_code == "cz" ~ "get_pvol_cz",
+    cntry_code == "se" ~ "get_pvol_se",
     .default = NA
   ))
   if (rlang::is_na(fun)) {

--- a/R/get_pvol_se.R
+++ b/R/get_pvol_se.R
@@ -26,14 +26,14 @@ get_pvol_se <- function(radar, time, ..., call = rlang::caller_env()) {
   radar_name <- get_pvol_se_radar_mapping[radar]
   url <- glue::glue(
     getOption(
-      "getRad.se_url_path_format",
+      "getRad.se_path_format",
       '/area/{radar_name}/product/qcvol/{lubridate::year(time)}/{lubridate::month(time)}/{lubridate::day(time)}/radar_{radar_name}_qcvol_{strftime(time, "%Y%m%d%H%M", tz="UTC" )}.h5'
     )
   )
   req <- withCallingHandlers(
     httr2::request(
       getOption(
-        "getRad.se_base_url",
+        "getRad.se_url",
         "https://opendata-download-radar.smhi.se/api/version/latest"
       )
     ) |>

--- a/R/get_pvol_se.R
+++ b/R/get_pvol_se.R
@@ -1,8 +1,16 @@
 get_pvol_se_radar_mapping <- c(
-  "seang" = "angelholm", "seatv" = "atvidaberg", "sebaa" = "balsta",
-  "sehem" = "hemse", "sehuv" = "hudiksvall", "sekaa" = "karlskrona",
-  "sekrn" = "kiruna", "selek" = "leksand", "sella" = "lulea",
-  "seoer" = "ornskoldsvik", "seosd" = "ostersund", "sevax" = "vara"
+  "seang" = "angelholm",
+  "seatv" = "atvidaberg",
+  "sebaa" = "balsta",
+  "sehem" = "hemse",
+  "sehuv" = "hudiksvall",
+  "sekaa" = "karlskrona",
+  "sekrn" = "kiruna",
+  "selek" = "leksand",
+  "sella" = "lulea",
+  "seoer" = "ornskoldsvik",
+  "seosd" = "ostersund",
+  "sevax" = "vara"
 )
 
 get_pvol_se <- function(radar, time, ..., call = rlang::caller_env()) {

--- a/R/get_pvol_se.R
+++ b/R/get_pvol_se.R
@@ -24,10 +24,16 @@ get_pvol_se <- function(radar, time, ..., call = rlang::caller_env()) {
     )
   }
   radar_name <- get_pvol_se_radar_mapping[radar]
-  url <- glue::glue('/area/{radar_name}/product/qcvol/{lubridate::year(time)}/{lubridate::month(time)}/{lubridate::day(time)}/radar_{radar_name}_qcvol_{strftime(time, "%Y%m%d%H%M", tz="UTC" )}.h5')
+  url <- glue::glue(
+    getOption(
+      "getRad.se_url_path_format",
+      '/area/{radar_name}/product/qcvol/{lubridate::year(time)}/{lubridate::month(time)}/{lubridate::day(time)}/radar_{radar_name}_qcvol_{strftime(time, "%Y%m%d%H%M", tz="UTC" )}.h5'
+    )
+  )
   req <- withCallingHandlers(
     httr2::request(
-      "https://opendata-download-radar.smhi.se/api/version/latest"
+      getOption("getRad.se_base_url",
+                "https://opendata-download-radar.smhi.se/api/version/latest")
     ) |>
       req_user_agent_getrad() |>
       httr2::req_url_path_append(url) |>
@@ -39,7 +45,7 @@ get_pvol_se <- function(radar, time, ..., call = rlang::caller_env()) {
           i = "Volume data in Sweden is only available for 24 hours",
           i = "If the requested time is within the last 24 hours the error might relate to a server outage or package problem"
         ),
-        parent = cnd, call = call, url=url, class = "getRad_error_get_pvol_se_data_not_found"
+        parent = cnd, call = call, url = url, class = "getRad_error_get_pvol_se_data_not_found"
       )
     }
   )

--- a/R/get_pvol_se.R
+++ b/R/get_pvol_se.R
@@ -16,7 +16,7 @@ get_pvol_se <- function(radar, time, ..., call = rlang::caller_env()) {
     )
   }
   radar_name <- get_pvol_se_radar_mapping[radar]
-  url <- glue::glue('/area/{radar_name}/product/qcvol/{lubridate::year(time)}/{lubridate::month(time)}/{{lubridate::day(time)}}/radar_{radar_name}_qcvol_{strftime(time, "%Y%m%d%H%M", tz="UTC" )}.h5')
+  url <- glue::glue('/area/{radar_name}/product/qcvol/{lubridate::year(time)}/{lubridate::month(time)}/{lubridate::day(time)}/radar_{radar_name}_qcvol_{strftime(time, "%Y%m%d%H%M", tz="UTC" )}.h5')
   req <- withCallingHandlers(
     httr2::request(
       "https://opendata-download-radar.smhi.se/api/version/latest"
@@ -31,7 +31,7 @@ get_pvol_se <- function(radar, time, ..., call = rlang::caller_env()) {
           i = "Volume data in Sweden is only available for 24 hours",
           i = "If the requested time is within the last 24 hours the error might relate to a server outage or package problem"
         ),
-        parent = cnd, call = call, class = "getRad_error_get_pvol_se_data_not_found"
+        parent = cnd, call = call, url=url, class = "getRad_error_get_pvol_se_data_not_found"
       )
     }
   )

--- a/R/get_pvol_se.R
+++ b/R/get_pvol_se.R
@@ -32,8 +32,10 @@ get_pvol_se <- function(radar, time, ..., call = rlang::caller_env()) {
   )
   req <- withCallingHandlers(
     httr2::request(
-      getOption("getRad.se_base_url",
-                "https://opendata-download-radar.smhi.se/api/version/latest")
+      getOption(
+        "getRad.se_base_url",
+        "https://opendata-download-radar.smhi.se/api/version/latest"
+      )
     ) |>
       req_user_agent_getrad() |>
       httr2::req_url_path_append(url) |>

--- a/R/get_pvol_se.R
+++ b/R/get_pvol_se.R
@@ -1,0 +1,43 @@
+get_pvol_se_radar_mapping <- c(
+  "seang" = "angelholm", "seatv" = "atvidaberg", "sebaa" = "balsta",
+  "sehem" = "hemse", "sehuv" = "hudiksvall", "sekaa" = "karlskrona",
+  "sekrn" = "kiruna", "selek" = "leksand", "sella" = "lulea",
+  "seoer" = "ornskoldsvik", "seosd" = "ostersund", "sevax" = "vara"
+)
+
+get_pvol_se <- function(radar, time, ..., call = rlang::caller_env()) {
+  if (!radar %in% names(get_pvol_se_radar_mapping)) {
+    cli::cli_abort(
+      c(
+        x = "The radar {.val {radar}} is not found in the mapping for Swedish radars",
+        i = "Most likely this means an invalid odim code has been provided"
+      ),
+      call = call, class = "getRad_error_get_pvol_se_radar_not_found"
+    )
+  }
+  radar_name <- get_pvol_se_radar_mapping[radar]
+  url <- glue::glue('/area/{radar_name}/product/qcvol/{lubridate::year(time)}/{lubridate::month(time)}/{{lubridate::day(time)}}/radar_{radar_name}_qcvol_{strftime(time, "%Y%m%d%H%M", tz="UTC" )}.h5')
+  req <- withCallingHandlers(
+    httr2::request(
+      "https://opendata-download-radar.smhi.se/api/version/latest"
+    ) |>
+      req_user_agent_getrad() |>
+      httr2::req_url_path_append(
+        glue::glue(url)
+      ) |>
+      httr2::req_perform(path = tempfile(fileext = ".h5"), error_call = call),
+    httr2_http_404 = function(cnd) {
+      cli::cli_abort(
+        c(
+          x = "No polar volume data could be found for {.val {radar}} at time {.val {time}}",
+          i = "Volume data in Sweden is only available for 24 hours",
+          i = "If the requested time is within the last 24 hours the error might relate to a server outage or package problem"
+        ),
+        parent = cnd, call = call, class = "getRad_error_get_pvol_se_data_not_found"
+      )
+    }
+  )
+  pvol <- bioRad::read_pvolfile(req$body, ...)
+  file.remove(req$body)
+  pvol
+}

--- a/R/get_pvol_se.R
+++ b/R/get_pvol_se.R
@@ -22,9 +22,7 @@ get_pvol_se <- function(radar, time, ..., call = rlang::caller_env()) {
       "https://opendata-download-radar.smhi.se/api/version/latest"
     ) |>
       req_user_agent_getrad() |>
-      httr2::req_url_path_append(
-        glue::glue(url)
-      ) |>
+      httr2::req_url_path_append(url) |>
       httr2::req_perform(path = tempfile(fileext = ".h5"), error_call = call),
     httr2_http_404 = function(cnd) {
       cli::cli_abort(

--- a/tests/testthat/test-get_pvol_se.R
+++ b/tests/testthat/test-get_pvol_se.R
@@ -1,4 +1,5 @@
 test_that("Pvol for Sweden can be downloaded", {
+  skip_if_offline("opendata-download-radar.smhi.se")
   time <- as.POSIXct(Sys.time(), tz = "Europe/Helsinki") - lubridate::hours(10)
   expect_s3_class(pvol <- get_pvol("seatv", time, param = "all"), "pvol")
   expect_true(bioRad::is.pvol(pvol))
@@ -9,6 +10,7 @@ test_that("Pvol for Sweden can be downloaded", {
 })
 
 test_that("Pvol for Sweden fails out of time range", {
+  skip_if_offline("opendata-download-radar.smhi.se")
   time <- Sys.time() - lubridate::hours(40)
   expect_error(get_pvol("sehuv", time), class = "getRad_error_get_pvol_se_data_not_found")
   time <- Sys.time() + lubridate::hours(1)
@@ -16,6 +18,7 @@ test_that("Pvol for Sweden fails out of time range", {
 })
 
 test_that("Pvol for Sweden fails incorrect radar", {
+  skip_if_offline("opendata-download-radar.smhi.se")
   time <- Sys.time() - lubridate::hours(10)
   expect_error(get_pvol("sehut", time), class = "getRad_error_get_pvol_se_radar_not_found")
 })

--- a/tests/testthat/test-get_pvol_se.R
+++ b/tests/testthat/test-get_pvol_se.R
@@ -1,0 +1,21 @@
+test_that("Pvol for Sweden can be downloaded", {
+  time <- as.POSIXct(Sys.time(), tz = "Europe/Helsinki") - lubridate::hours(10)
+  expect_s3_class(pvol <- get_pvol("seatv", time, param = "all"), "pvol")
+  expect_true(bioRad::is.pvol(pvol))
+  expect_identical(
+    pvol$datetime,
+    lubridate::with_tz(lubridate::floor_date(time, "5 mins"), "UTC")
+  )
+})
+
+test_that("Pvol for Sweden fails out of time range", {
+  time <- Sys.time() - lubridate::hours(40)
+  expect_error(get_pvol("sehuv", time), class = "getRad_error_get_pvol_se_data_not_found")
+  time <- Sys.time() + lubridate::hours(1)
+  expect_error(get_pvol("sehuv", time), class = "getRad_error_get_pvol_se_data_not_found")
+})
+
+test_that("Pvol for Sweden fails incorrect radar", {
+  time <- Sys.time() - lubridate::hours(10)
+  expect_error(get_pvol("sehut", time), class = "getRad_error_get_pvol_se_radar_not_found")
+})

--- a/vignettes/supported_sources.Rmd
+++ b/vignettes/supported_sources.Rmd
@@ -23,7 +23,7 @@ require(leaflet)
 require(rnaturalearth)
 included_countries <- dplyr::tribble(
   ~code, ~description, ~time, ~supported, ~license, ~links,
-  "se", "Data is publicly available", "Data is only available for 24 hours","Readable","CC BY 4.0 SE<sup><a href='https://www.smhi.se/data/om-smhis-data/villkor-for-anvandning'>1</a></sup>",c("API documentation"="https://opendata.smhi.se/radar/api"),
+  "se", "Data is publicly available", "Data is only available for 24 hours","Readable","CC BY 4.0 SE<sup><a href='https://www.smhi.se/data/om-smhis-data/villkor-for-anvandning'>1</a></sup>",c("API documentation"="https://opendata.smhi.se/radar/api","Documentation of radar products"="https://www.smhi.se/data/sok-oppna-data-i-utforskaren/meteorologiska-observationer-radar-sverigekomposit-och-enskilda-volymer"),
   "us", "Data is available in an aws S3 bucket", NA, "Readable", "NOAA data disseminated through NODD are open to the public and can be used as desired<sup> <a href='https://registry.opendata.aws/noaa-nexrad/'>1</a>", c("Bucket" = "https://noaa-nexrad-level2.s3.amazonaws.com/index.html", "More info" = "https://www.ncei.noaa.gov/products/radar/next-generation-weather-radar"),
   "be", "Data is suggested to be opened into the future, it is however not yet accessible.", NA, "Information", NA, c("More info" = "https://opendata.meteo.be/geonetwork/srv/eng/catalog.search#/metadata/RMI_DATASET_JABBEKE_VOLUME"),
   "pl", "Volume data should be open according to a presentation by <a href='https://poster.easyabstract.it/ERAD2024/abstract/15550/161/884'>Groenemeijer et al</a> at erad2024. However no link is known by the authors of the package up to now.", NA, "Information", NA, list(),

--- a/vignettes/supported_sources.Rmd
+++ b/vignettes/supported_sources.Rmd
@@ -23,6 +23,7 @@ require(leaflet)
 require(rnaturalearth)
 included_countries <- dplyr::tribble(
   ~code, ~description, ~time, ~supported, ~license, ~links,
+  "se", "Data is publicly available", "Data is only available for 24 hours","Readable","CC BY 4.0 SE<sup><a href='https://www.smhi.se/data/om-smhis-data/villkor-for-anvandning'>1</a></sup>",c("API documentation"="https://opendata.smhi.se/radar/api"),
   "us", "Data is available in an aws S3 bucket", NA, "Readable", "NOAA data disseminated through NODD are open to the public and can be used as desired<sup> <a href='https://registry.opendata.aws/noaa-nexrad/'>1</a>", c("Bucket" = "https://noaa-nexrad-level2.s3.amazonaws.com/index.html", "More info" = "https://www.ncei.noaa.gov/products/radar/next-generation-weather-radar"),
   "be", "Data is suggested to be opened into the future, it is however not yet accessible.", NA, "Information", NA, c("More info" = "https://opendata.meteo.be/geonetwork/srv/eng/catalog.search#/metadata/RMI_DATASET_JABBEKE_VOLUME"),
   "pl", "Volume data should be open according to a presentation by <a href='https://poster.easyabstract.it/ERAD2024/abstract/15550/161/884'>Groenemeijer et al</a> at erad2024. However no link is known by the authors of the package up to now.", NA, "Information", NA, list(),


### PR DESCRIPTION
# AI Summary

This pull request introduces support for downloading Swedish radar data, including a new function, tests, and documentation updates. The changes ensure compatibility with Swedish data sources and provide error handling for common issues.

### Support for Swedish Radar Data:

* Added a new function `get_pvol_se` in `R/get_pvol_se.R` to handle downloading and processing radar data from Sweden, including a radar mapping and error handling for invalid radar codes and unavailable data.
* Updated `select_get_pvol_function` in `R/get_pvol.R` to include Sweden (`cntry_code == "se"`) in the country-specific radar data retrieval logic.

### Testing:

* Added tests in `tests/testthat/test-get_pvol_se.R` to verify successful data retrieval for Sweden, proper handling of time range errors, and validation of radar codes.

### Documentation:

* Updated `NEWS.md` to announce support for downloading Swedish data.
* Updated `vignettes/supported_sources.Rmd` to include Sweden in the list of supported countries, with details on data availability and licensing.