### PR TITLE
fix #139

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 * Improve error for requesting German data out of temporal restrictions (#131).
 * Start using the air formatter (#128).
 * Do not fail but rather warn when csv is missing from repository (#136).
+* In `get_pvol` correct where attributes for German data causing incorrect `vp` heights (#139). 
 
 # getRad 0.2.2
 

--- a/R/get_pvol_de.R
+++ b/R/get_pvol_de.R
@@ -143,8 +143,26 @@ list_to_pvol <- function(
   ))
   output$attributes$what$object <- "PVOL"
   output$attributes$what$source <- source
-  output$geo <- attr(purrr::chuck(x, 1, "params", 1), "geo")
-
+  # Remove scan specific how attributes (there might be more)
+  output$attributes$how[c(
+    "NI",
+    "highprf",
+    "lowprf",
+    "scan_index",
+    "startazA",
+    "startazT",
+    "startelA",
+    "stopazA",
+    "stopazT",
+    "stopelA",
+    "task"
+  )] <- NULL
+  output$geo <- attr(purrr::chuck(x, 1, "params", 1), "geo")[c(
+    "lat",
+    "lon",
+    "height"
+  )]
+  output$attributes$where <- output$geo
   class(output) <- "pvol"
   output
 }

--- a/tests/testthat/test-get_pvol_de.R
+++ b/tests/testthat/test-get_pvol_de.R
@@ -10,6 +10,8 @@ test_that("Pvol for German can be downloaded", {
     lubridate::floor_date(pvol$datetime, "5 mins"),
     lubridate::with_tz(time, "UTC")
   )
+  expect_named(pvol$geo, c("lat", "lon", "height"))
+  expect_named(pvol$attributes$where, c("lat", "lon", "height"))
 })
 test_that("Correct error for old German data", {
   skip_if_offline(host = "opendata.dwd.de")


### PR DESCRIPTION
Now the vp starts at the correct altitude (same as baltrad)

``` r
devtools::load_all("~/getRad/")
#> ℹ Loading getRad
plot(bioRad::calculate_vp(get_pvol("detur",Sys.time()-1000)))
#> Running vol2birdSetUp
#> Warning: no dual-pol moments found, switching to SINGLE POL mode
```

![](https://i.imgur.com/ZsyL2Xk.png)<!-- -->

