### PR TITLE
Update meta to use direct links

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -81,8 +81,7 @@ for (i in names(vpts_list)) {
 
 ## Meta
 
-- We welcome [contributions](https://aloftdata.github.io/getRad/CONTRIBUTING.html) including bug reports.
+- We welcome [contributions](.github/CONTRIBUTING.md) including bug reports.
 - License: MIT
-- Get [citation information](https://aloftdata.github.io/getRad/authors.html#citation) for getRad in R doing `citation("getRad")`.
-- Please note that this project is released with a [Contributor Code of Conduct](https://aloftdata.github.io/getRad/CODE_OF_CONDUCT.html). By participating in this project you agree to abide by its terms.
-
+- Get citation information for getRad in R with `citation("getRad")`.
+- Please note that this project is released with a [Contributor Code of Conduct](.github/CODE_OF_CONDUCT.md). By participating in this project you agree to abide by its terms.

--- a/README.md
+++ b/README.md
@@ -98,13 +98,10 @@ for (i in names(vpts_list)) {
 
 ## Meta
 
-- We welcome
-  [contributions](https://aloftdata.github.io/getRad/CONTRIBUTING.html)
-  including bug reports.
+- We welcome [contributions](.github/CONTRIBUTING.md) including bug
+  reports.
 - License: MIT
-- Get [citation
-  information](https://aloftdata.github.io/getRad/authors.html#citation)
-  for getRad in R doing `citation("getRad")`.
+- Get citation information for getRad in R with `citation("getRad")`.
 - Please note that this project is released with a [Contributor Code of
-  Conduct](https://aloftdata.github.io/getRad/CODE_OF_CONDUCT.html). By
-  participating in this project you agree to abide by its terms.
+  Conduct](.github/CODE_OF_CONDUCT.md). By participating in this project
+  you agree to abide by its terms.


### PR DESCRIPTION
There's no need to manually link to the pkgdown website:

- On GitHub, it will link to GitHub files
- On pkgdown, it will link to pkgdown pages